### PR TITLE
FIX: metaparameter variables should not be specified

### DIFF
--- a/manifests/bit.pp
+++ b/manifests/bit.pp
@@ -17,9 +17,5 @@ define bitfile::bit(
 		content         => $content,
 		source          => $source,
 		closing_content => $closing_content,
-		before          => $before,
-		require         => $require,
-		notify          => $notify,
-		subscribe       => $subscribe,
 	}
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,9 +7,5 @@ define bitfile(
 		mode      => $mode,
 		owner     => $owner,
 		group     => $group,
-		before    => $before,
-		require   => $require,
-		notify    => $notify,
-		subscribe => $subscribe,
 	}
 }


### PR DESCRIPTION
* they are automatically inherited
* they aren't available by name here
* prior to this change the net effect would be explicitly setting them
  to undef for any underscore_bit_file_bit resources